### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/complete/gateway/src/test/java/hello/filters/pre/SimpleFilterTest.java
+++ b/complete/gateway/src/test/java/hello/filters/pre/SimpleFilterTest.java
@@ -43,11 +43,11 @@ public class SimpleFilterTest {
     public void testRun() {
         HttpServletRequest req = mock(HttpServletRequest.class);
         when(req.getMethod()).thenReturn("GET");
-        when(req.getRequestURL()).thenReturn(new StringBuffer("http://foo"));
+        when(req.getRequestURL()).thenReturn(new StringBuffer("https://foo"));
         RequestContext context = mock(RequestContext.class);
         when(context.getRequest()).thenReturn(req);
         RequestContext.testSetCurrentContext(context);
         filter.run();
-        this.outputCapture.expect(Matchers.containsString("GET request to http://foo"));
+        this.outputCapture.expect(Matchers.containsString("GET request to https://foo"));
     }
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://foo (UnknownHostException) with 2 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/books/available with 1 occurrences
* http://localhost:8090 with 1 occurrences